### PR TITLE
Rework to use SSL vhost, apache and common roles

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,20 @@
 ---
-#graphite_vhost: graphite.example.com
+#graphite_domain: graphite.example.com
 #graphite_secret_csrf_key: eeLahch5Ahqueih8chuthi9A
+
+# uncomment to enable ssl vhost
+#graphite_ssl_listen: 14446
+
+#graphite_ssl_cert: "/etc/letsencrypt/live/{{ graphite_domain }}/cert.pem"
+#graphite_ssl_key: "/etc/letsencrypt/live/{{ graphite_domain }}/privkey.pem"
+#graphite_ssl_chain: "/etc/letsencrypt/live/{{ graphite_domain }}/chain.pem"
+
+devel_ssl_cert: /etc/pki/tls/certs/localhost.crt
+devel_ssl_key: /etc/pki/tls/private/localhost.key
+
+graphite_ssl_cert: "{{ devel_ssl_cert }}"
+graphite_ssl_key: "{{ devel_ssl_key }}"
+graphite_ssl_chain: "{{ devel_ssl_key }}"
 
 graphite_line_interface: 0.0.0.0
 graphite_line_port: 2003

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,6 @@ galaxy_info:
   - graphite
   - carbon
 
-dependencies: []
+dependencies:
+   - role: nestihacky.common
+   - role: nestihacky.apache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,31 @@
   - libsemanage-python
   - mod_ssl
 
+- seport:
+    ports: "{{ graphite_ssl_listen }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when: common_selinux
+
 - name: graphite-web config file
   template: src=local_settings.py dest=/etc/graphite-web/local_settings.py owner=root group=root mode=644
   notify:
   - restart httpd
 
+- name: create data directory
+  file:
+    path: /etc/httpd/conf.d/graphite/
+    state: directory
+
 - name: graphite-web apache config
-  template: src=graphite-web.conf dest=/etc/httpd/conf.d/graphite-web.conf owner=root group=root mode=644
+  template: src=graphite-web.conf dest=/etc/httpd/conf.d/graphite/graphite-web.conf owner=root group=root mode=644
+  notify:
+  - restart httpd
+
+- name: graphite-web apache ssl config
+  template: src=graphite-ssl.conf dest=/etc/httpd/conf.d/graphite-ssl.conf owner=root group=root mode=644
+  when: graphite_ssl_listen is defined
   notify:
   - restart httpd
 

--- a/templates/graphite-ssl.conf
+++ b/templates/graphite-ssl.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+  ServerName {{ graphite_domain }}
+  Redirect permanent / https://{{ graphite_domain }}/
+</VirtualHost>
+
+Listen {{ graphite_ssl_listen }} ssl
+
+<VirtualHost *:{{ graphite_ssl_listen }}>
+  ServerName {{ graphite_domain }}
+
+  SSLEngine on
+  SSLProtocol {{ apache_ssl_protocol }}
+  SSLCipherSuite {{ apache_ssl_cipher_suite }}
+
+  SSLCertificateFile {{ graphite_ssl_cert }}
+  SSLCertificateChainFile {{ graphite_ssl_chain }}
+  SSLCertificateKeyFile {{ graphite_ssl_key }}
+
+  Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
+
+  ErrorLog logs/graphite_ssl_error_log
+  TransferLog logs/graphite_ssl_access_log
+  LogLevel warn
+
+  Include conf.d/graphite/graphite-web.conf
+</VirtualHost>

--- a/templates/graphite-web.conf
+++ b/templates/graphite-web.conf
@@ -1,37 +1,26 @@
-<VirtualHost *:80>
-    ServerName {{ graphite_vhost }}
-    DocumentRoot "/usr/share/graphite/webapp"
-    ErrorLog /var/log/httpd/graphite-web-error.log
-    CustomLog /var/log/httpd/graphite-web-access.log common
+DocumentRoot "/usr/share/graphite/webapp"
 
-    Header set Access-Control-Allow-Origin "*"
-    # Header set Access-Control-Allow-Methods "GET, OPTIONS"
-    # Header set Access-Control-Allow-Headers "origin, authorization, accept"
-    # Header set Access-Control-Allow-Credentials true
+Header set Access-Control-Allow-Origin "*"
+# Header set Access-Control-Allow-Methods "GET, OPTIONS"
+# Header set Access-Control-Allow-Headers "origin, authorization, accept"
+# Header set Access-Control-Allow-Credentials true
 
-    WSGIScriptAlias / /usr/share/graphite/graphite-web.wsgi
-    WSGIImportScript /usr/share/graphite/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
+WSGIScriptAlias / /usr/share/graphite/graphite-web.wsgi
+WSGIImportScript /usr/share/graphite/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
 
-    <Location "/content/">
-        SetHandler None
-    </Location>
+<Location "/content/">
+    SetHandler None
+</Location>
 
-    Alias /media/ "/usr/lib/python2.7/site-packages/django/contrib/admin/media/"
-    <Location "/media/">
-        SetHandler None
-    </Location>
+Alias /media/ "/usr/lib/python2.7/site-packages/django/contrib/admin/media/"
+<Location "/media/">
+    SetHandler None
+</Location>
 
-   #<Directory "/usr/share/graphite/">
-   #    <IfModule mod_authz_core.c>
-   #        # Apache 2.4
-   #        Require local
-   #    </IfModule>
-   #    <IfModule !mod_authz_core.c>
-   #        # Apache 2.2
-   #        Order Deny,Allow
-   #        Deny from all
-   #        Allow from 127.0.0.1
-   #        Allow from ::1
-   #    </IfModule>
-   #</Directory>
-</VirtualHost>
+<Directory "/usr/share/graphite/">
+    <IfModule mod_authz_core.c>
+        <Files graphite-web.wsgi>
+            Require all granted
+        </Files>
+    </IfModule>
+</Directory>


### PR DESCRIPTION
Also changes graphite_vhost to graphite_domain to match the rest.

Puts webapp config to /etc/httpd/conf.d/graphite/graphite-web.conf so
it's not included by default.

Obosletes PR#1

Do we want to have non-ssl vhost as well or some access control for ssl one enabled?